### PR TITLE
Generalize the operator pattern, plus some minor tweaks

### DIFF
--- a/syntax/haskell.vim
+++ b/syntax/haskell.vim
@@ -91,8 +91,8 @@ syn match hsOperator "`[a-zA-Z0-9\.]\+`"
 " after a name.  This allows whitespace before the name so that it can match
 " in a 'where,' but it won't match local type annotations on random little
 " things.
-syn match hsFunctionList "^\s*\([a-z][a-zA-Z0-9']*[[:space:]\n,]\+\)*[a-z][a-zA-Z0-9']*[[:space:]\n]*::" contains=hsFunction
-syn match hsFunction "\s*[a-z][a-zA-Z0-9']*[[:space:]\n]*\(::\|,\)\@=" contained
+syn match hsFunctionList "^\s*\(\<\(where\|let\>\)\@![a-z][a-zA-Z0-9']*[[:space:]\n,]\+\)*[a-z][a-zA-Z0-9']*[[:space:]\n]*::" contains=hsFunction
+syn match hsFunction "\s*[a-z][a-zA-Z0-9']*\([[:space:]\n]*\(::\|,\)\)\@=" contained
 " Also support the style where the first where binding is on the same line as
 " the where keyword.
 syn match hsFunction "\(^\s\+where\s\+\)\@<=[a-z][a-zA-Z0-9']*\(\s*::\)\@="

--- a/syntax/haskell.vim
+++ b/syntax/haskell.vim
@@ -77,13 +77,10 @@ syn keyword hsTypeDecls class instance data newtype type deriving default
 " only a keyword if it follows data/type...
 
 " We want to let '-' participate in operators, but we can't let it match
-" '--', '---', etc. because that interferes with comments.
-syn match hsOperator "\(--\+\([^%\~\&\*/\$\^|@:+<!>=#!\?]\|$\)\)\@![-%\~\&\*/\$\^|@:+<!>=#!\?]\+"
-" A bare . is an operator (but not surrounded by alnum chars)
-syn match hsOperator "\s\@<=\.\s\@="
-" . is also an operator if adjacent to some other operator char
-syn match hsOperator "[-%\~\&\*\$\^|@:+<!>=#!\?]\+\.[-%\~\&\*\$\^|@:+<\.!>=#!\?]*"
-syn match hsOperator "[-%\~\&\*\$\^|@:+<!>=#!\?]*\.[-%\~\&\*\$\^|@:+\.<!>=#!\?]\+"
+" '--', '---', etc. because it interferes with comments. The same goes for
+" '#!' at the start of a file. Also, the dot (.) is an operator character,
+" but not when it comes immediately after a module name.
+syn match hsOperator "\(\%^\#\!\)\@!\(\(\<[A-Z]\w*\)\@64<=\.\)\@!\(--\+\([^.%\~\&\*/\$\^|@:+<!>=#!\?]\|$\)\)\@![-.%\~\&\*/\$\^|@:+<!>=#!\?]\+"
 " Include support for infix functions as operators
 syn match hsOperator "`[a-zA-Z0-9\.]\+`"
 

--- a/syntax/haskell.vim
+++ b/syntax/haskell.vim
@@ -76,15 +76,14 @@ syn keyword hsTypeDecls class instance data newtype type deriving default
 " FIXME: Maybe we can do something fancy for data/type families?  'family' is
 " only a keyword if it follows data/type...
 
-" This is uglier than I'd like.  We want to let '-' participate in operators,
-" but we can't let it match '--' because that interferes with comments.  Hacks
-" for now - just include some common operators with '-'.
-syn match hsOperator "<-\|->\|-->\|-\(-\)\@!\|[%\~\&\*/\$\^|@:+<!>=#!\?]\+"
+" We want to let '-' participate in operators, but we can't let it match
+" '--', '---', etc. because that interferes with comments.
+syn match hsOperator "\(--\+\([^%\~\&\*/\$\^|@:+<!>=#!\?]\|$\)\)\@![-%\~\&\*/\$\^|@:+<!>=#!\?]\+"
 " A bare . is an operator (but not surrounded by alnum chars)
 syn match hsOperator "\s\@<=\.\s\@="
 " . is also an operator if adjacent to some other operator char
-syn match hsOperator "[%\~\&\*\$\^|@:+<!>=#!\?]\+\.[%\~\&\*\$\^|@:+<\.!>=#!\?]*"
-syn match hsOperator "[%\~\&\*\$\^|@:+<!>=#!\?]*\.[%\~\&\*\$\^|@:+\.<!>=#!\?]\+"
+syn match hsOperator "[-%\~\&\*\$\^|@:+<!>=#!\?]\+\.[-%\~\&\*\$\^|@:+<\.!>=#!\?]*"
+syn match hsOperator "[-%\~\&\*\$\^|@:+<!>=#!\?]*\.[-%\~\&\*\$\^|@:+\.<!>=#!\?]\+"
 " Include support for infix functions as operators
 syn match hsOperator "`[a-zA-Z0-9\.]\+`"
 

--- a/syntax/haskell.vim
+++ b/syntax/haskell.vim
@@ -27,7 +27,7 @@ syn match  hsFloat            "\<[0-9]\+\.[0-9]\+\([eE][-+]\=[0-9]\+\)\=\>"
 " a capital letter.  Note that this also handles the case of @M.lookup@ where
 " M is a qualified import.  There is a big negative lookbehind assertion here
 " so that we don't highlight import and module statements oddly.
-syn match hsTypeName "\(^import\s.*\|^module\s.*\)\@<!\([^a-zA-Z0-9]\)\@<=[A-Z][a-zA-Z0-9_]*"
+syn match hsTypeName "\(^import\s.*\|^module\s.*\)\@<!\(^\|[^a-zA-Z0-9]\)\@<=[A-Z][a-zA-Z0-9_]*"
 " Also make unit and the empty list easy to spot - they are constructors too.
 syn match hsTypeName "()"
 syn match hsTypeName "\[\]"

--- a/syntax/haskell.vim
+++ b/syntax/haskell.vim
@@ -51,6 +51,8 @@ syn region hsHaddockComment start='-- ^' end='^\(\s*--\)\@!' contains=hsFIXME,@S
 syn match hsHaddockSection '-- \*.*$'
 " Named documentation chunks (also for import lists)
 syn match hsHaddockSection '-- \$.*$'
+" Treat a shebang line at the start of the file as a comment
+syn match hsLineComment "\%^\#\!.*$"
 
 
 " Keywords appearing in expressions, plus a few top-level keywords

--- a/syntax/haskell.vim
+++ b/syntax/haskell.vim
@@ -90,11 +90,11 @@ syn match hsOperator "`[a-zA-Z0-9\.]\+`"
 " after a name.  This allows whitespace before the name so that it can match
 " in a 'where,' but it won't match local type annotations on random little
 " things.
-syn match hsFunctionList "^\s*\(\<\(where\|let\>\)\@![a-z][a-zA-Z0-9']*[[:space:]\n,]\+\)*[a-z][a-zA-Z0-9']*[[:space:]\n]*::" contains=hsFunction
+syn match hsFunctionList "^\s*\(\<\(where\>\|let\>\)\@![a-z][a-zA-Z0-9']*[[:space:]\n,]\+\)*[a-z][a-zA-Z0-9']*[[:space:]\n]*::" contains=hsFunction
 syn match hsFunction "\s*[a-z][a-zA-Z0-9']*\([[:space:]\n]*\(::\|,\)\)\@=" contained
 " Also support the style where the first where binding is on the same line as
 " the where keyword.
-syn match hsFunction "\(^\s\+where\s\+\)\@<=[a-z][a-zA-Z0-9']*\(\s*::\)\@="
+syn match hsFunction "\(\<\(where\|let\)\s\+\([a-z][a-zA-Z0-9']*\s*,\s*\)*\)\@<=[a-z][a-zA-Z0-9']*\(\s*\(,\s*[a-z][a-zA-Z0-9']*\s*\)*::\)\@="
 
 " FIXME Ignoring proc for now, also mdo and rec
 

--- a/syntax/haskell.vim
+++ b/syntax/haskell.vim
@@ -68,7 +68,9 @@ syn keyword hsConditional case of if then else
 " headers (-- *) can be highlighted specially only within this context.
 syn region hsModuleHeader start="^module\s" end="where" contains=hsHaddockSection keepend fold transparent
 " Treat Module imports as the #include category; it maps reasonably well
-syn keyword hsImport import qualified as hiding module
+syn keyword hsImport import module
+" Treat 'qualified', 'as', and 'hiding' as keywords when following 'import'
+syn match hsImport '\(\<import\>.*\)\@<=\<\(qualified\|as\|hiding\)\>'
 
 syn keyword hsTypeDecls class instance data newtype type deriving default
 " FIXME: Maybe we can do something fancy for data/type families?  'family' is


### PR DESCRIPTION
1) Adjusted the pattern for hsOperator to include any sequence of operator characters other than two or more hyphens (so `-->` and `>--` are accepted, but `--` and `---` are not).

2) Adjusted the pattern for multi-character operators containing `.` to allow hyphens before and/or after the `.` (e.g. `.-` or `-.-`.)

3) The rule for type names only matched names preceded by a non-alphanumeric character. I added a case for matching type names at the beginning of a line.

4) The strings `qualified`, `as`, and `hiding` are only keywords within an import statement. In particular, `as` is often used to denote a list, e.g. `(a:as)`. I replaced the keyword declaration with a match statement similar to the one for the `family` keyword following `data` or `type`.
